### PR TITLE
Fix launch.json for latest vscode. Add simple settings functionality so we can always keep the same port in iis express (issue 2).

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "out/src",
+			"outDir": "${workspaceRoot}/out/src",
 			"preLaunchTask": "npm"
 		},
 		{
@@ -21,7 +21,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "out/test",
+			"outDir": "${workspaceRoot}/out/test",
 			"preLaunchTask": "npm"
 		}
 	]

--- a/src/IISExpress.ts
+++ b/src/IISExpress.ts
@@ -104,15 +104,3 @@ export class IIS {
     
     
 }
-
-//IIS Express docs recommend ports greater than 1024
-//http://www.iis.net/learn/extensions/using-iis-express/running-iis-express-without-administrative-privileges
-export function getRandomPort():number{
-    return getRandomIntInclusive(1024,44399);
-}
-
-// Returns a random integer between min (included) and max (included)
-//https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random
-function getRandomIntInclusive(min:number, max:number):number {
-    return Math.floor(Math.random() * (max - min + 1)) + min;
-}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@
 import * as vscode from 'vscode';
 import * as iis from './IISExpress';
 import * as verify from './verification';
+import * as settingsHelpers from './settings';
 
 
 // this method is called when your extension is activated
@@ -11,11 +12,13 @@ export function activate(context: vscode.ExtensionContext) {
     
     //Begin checks of OS, IISExpress location etc..
     let verification = verify.checkForProblems();
+    
+    let settings = settingsHelpers.getSettings();
 
     //IISExpress command line arguments
     let args: iis.IExpressArguments = {
         path: verification.folderPath,
-        port: iis.getRandomPort()
+        port: settings.port
     };
 
     //Run IISExpress Class Contructor

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,55 @@
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as vscode from 'vscode';
+
+interface Isettings {
+    port: number;
+}
+
+
+export function getSettings():Isettings{
+    //Give some default values
+    let settings:Isettings = {
+        port : getRandomPort()
+    };
+    
+    // *******************************************
+    // Checks that iisexpress.json exist
+    // *******************************************
+	let settingsFilePath = vscode.workspace.rootPath + "\\.vscode\\iisexpress.json";
+    //use -> https://www.npmjs.com/package/jsonfile
+    var jsonfile = require('jsonfile');
+    
+    try {
+        //Check if we can find the file path (get stat info on it)
+        let fileCheck = fs.statSync(settingsFilePath);
+        //read file .vscode\iisexpress.json and overwrite port property from iisexpress.json
+        settings = jsonfile.readFileSync(settingsFilePath);
+    }
+    catch (err) {
+        //file didn't exist so
+        //create .vscode\iisexpress.json and append settings object
+       	jsonfile.writeFile(settingsFilePath, settings, {spaces: 2}, function (err) {
+            console.error(err);
+        });
+    }
+    
+    //Return an object back from verifications
+    return settings;
+    
+}
+
+
+//IIS Express docs recommend ports greater than 1024
+//http://www.iis.net/learn/extensions/using-iis-express/running-iis-express-without-administrative-privileges
+export function getRandomPort():number{
+    return getRandomIntInclusive(1024,44399);
+}
+
+
+// Returns a random integer between min (included) and max (included)
+//https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random
+function getRandomIntInclusive(min:number, max:number):number {
+    return Math.floor(Math.random() * (max - min + 1)) + min;
+}


### PR DESCRIPTION
two things 
1. Fix launch.json for latest vscode. 
2. Add simple settings functionality so we can always keep the same port in iis express (issue 2).