### PR TITLE
Fix duplicate output channel

### DIFF
--- a/src/IISExpress.ts
+++ b/src/IISExpress.ts
@@ -46,7 +46,7 @@ export class IIS {
 		this._iisProcess = process.spawn(this._iisPath, [`-path:${this._args.path}`,`-port:${this._args.port}`]);
 		
 		//Create output channel & show it
-		this._output = vscode.window.createOutputChannel('IIS Express');
+		this._output = this._output || vscode.window.createOutputChannel('IIS Express');
 		this._output.show(vscode.ViewColumn.Three);
 		
 		//Create Statusbar item & show it


### PR DESCRIPTION
Duplicate output channel at launch the site twice.

![iisduplicate](https://cloud.githubusercontent.com/assets/1356444/17029757/6f814036-4fa7-11e6-80eb-d553b041f0ac.png)
