### PR TITLE
adding default clr setting set to 'v4.0' to pass to iisexpress so it can be changed to 'v2.0' for those older projects

### DIFF
--- a/src/IISExpress.ts
+++ b/src/IISExpress.ts
@@ -6,6 +6,7 @@ var iconv=require('iconv-lite')
 export interface IExpressArguments {
 	path?: string;
 	port?: number;
+	clr?: string;
 }
 
 // TODO:
@@ -17,7 +18,8 @@ export class IIS {
 	private _args: IExpressArguments;
 	private _output: vscode.OutputChannel;
 	private _statusbar: vscode.StatusBarItem;
-	
+	private _statusMessage: string;
+
 	constructor(iisPath: string, args: IExpressArguments){
 		this._iisPath = iisPath;
 		this._args = args;
@@ -47,9 +49,12 @@ export class IIS {
 		//Folder to run as the arg
 		this._args.path = settings.path ? settings.path : vscode.workspace.rootPath;
 
+		//CLR version, yes there are still people on 3.5
+		this._args.clr = settings.clr;	
+
 		//This is the magic that runs the IISExpress cmd
-		this._iisProcess = process.spawn(this._iisPath, [`-path:${this._args.path}`,`-port:${this._args.port}`]);
-		
+		this._iisProcess = process.spawn(this._iisPath, [`-path:${this._args.path}`,`-port:${this._args.port}`,`-clr:${this._args.clr}`]);
+		console.log(`stdout: Command with Params ${this._iisPath} ${[`-path:${this._args.path}`,`-port:${this._args.port}`,`-clr:${this._args.clr}`].join(' ')}`);
 		//Create output channel & show it
 		this._output = this._output || vscode.window.createOutputChannel('IIS Express');
 		this._output.show(vscode.ViewColumn.Three);
@@ -59,7 +64,8 @@ export class IIS {
 		
 		//Set props on statusbar & show it
 		this._statusbar.text = `$(browser) http://localhost:${this._args.port}`;
-		this._statusbar.tooltip = `Running folder '${this._args.path}' as a website on http://localhost:${this._args.port}`;
+		this._statusMessage = `Running folder '${this._args.path}' as a website on http://localhost:${this._args.port} on CLR: ${this._args.clr}`;
+		this._statusbar.tooltip = this._statusMessage;
 		this._statusbar.command = 'extension.iis-express.open';
 		this._statusbar.show();
 		
@@ -87,7 +93,7 @@ export class IIS {
 		
 		
 		//Display Message
-		vscode.window.showInformationMessage(`Running folder '${this._args.path}' as a website on http://localhost:${this._args.port}`);
+		vscode.window.showInformationMessage(this._statusMessage);
 	}
 	
 	public stopWebsite(){

--- a/src/IISExpress.ts
+++ b/src/IISExpress.ts
@@ -6,7 +6,7 @@ var iconv=require('iconv-lite')
 export interface IExpressArguments {
 	path?: string;
 	port?: number;
-	clr?: string;
+	clr?: settingsHelpers.clrVersion;
 }
 
 // TODO:

--- a/src/iisexpress-schema.json
+++ b/src/iisexpress-schema.json
@@ -14,6 +14,10 @@
         "path": {
             "type": "string",
             "description": "This property is optional & allows you to set a path to the folder or subfolder as the root of your site/project for IIS Express to run"
+        },
+        "clr":{
+            "type": "string",
+            "description": "This property is optional & allows you to set AppPool CLR version, 2.0 vs 4.0"
         }
     },
     "required": [

--- a/src/iisexpress-schema.json
+++ b/src/iisexpress-schema.json
@@ -1,9 +1,12 @@
 {
 	"title": "JSON schema for VS Code IIS Express configuration file",
 	"$schema": "http://json-schema.org/draft-04/schema#",
-
+    "definitions": {
+        "clr": {
+            "enum": ["v2.0","v4.0"]
+        }
+    },
 	"type": "object",
-
 	 "properties": {
          "port": {
              "type": "integer",
@@ -16,7 +19,7 @@
             "description": "This property is optional & allows you to set a path to the folder or subfolder as the root of your site/project for IIS Express to run"
         },
         "clr":{
-            "type": "string",
+            "$ref": "#/definitions/clr",
             "description": "This property is optional & allows you to set AppPool CLR version, 2.0 vs 4.0"
         }
     },

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,16 +6,19 @@ import * as vscode from 'vscode';
 interface Isettings {
     port: number;
     path: string;
-    clr: string;
+    clr: clrVersion;
 }
-
+export enum clrVersion {
+	v20 = <any>"v2.0",
+	v40 = <any>"v4.0"
+}
 
 export function getSettings():Isettings{
     //Give some default values
     let settings:Isettings = {
         port : getRandomPort(),
         path: vscode.workspace.rootPath,
-        clr: "v4.0"
+        clr: clrVersion.v40
     };
     
     // *******************************************

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,6 +6,7 @@ import * as vscode from 'vscode';
 interface Isettings {
     port: number;
     path: string;
+    clr: string;
 }
 
 
@@ -13,7 +14,8 @@ export function getSettings():Isettings{
     //Give some default values
     let settings:Isettings = {
         port : getRandomPort(),
-        path: vscode.workspace.rootPath
+        path: vscode.workspace.rootPath,
+        clr: "v4.0"
     };
     
     // *******************************************


### PR DESCRIPTION
Simply adding CLR as another parameter to have in settings, needed for an older .net 3.5 project.

from the docs:
```/clr:clr-version The .NET Framework version (e.g. v2.0) to use to run the application. The default value is v4.0. You must also specify the /path option.``` 