### PR TITLE
Added support for WSL

### DIFF
--- a/src/IISExpress.ts
+++ b/src/IISExpress.ts
@@ -194,17 +194,16 @@ export class IIS {
 			//Stop function from running
 			return;
 		}
-
 		
 		if (options && options.url) {
 			//We have a starting URL set - but lets ensure we strip starting / if present
 			let startUrl = options.url.startsWith('/') ? options.url.substring(1) : options.url;
 
 			//Start browser with start url
-			process.exec(`start ${this._args.protocol}://localhost:${this._args.port}/${startUrl}`);
+			process.exec(`powershell.exe /c start ${this._args.protocol}://localhost:${this._args.port}/${startUrl}`);
     	} else {
 			//Uses the 'start' command & url to open default browser
-			process.exec(`start ${this._args.protocol}://localhost:${this._args.port}`);
+			process.exec(`powershell.exe /c start ${this._args.protocol}://localhost:${this._args.port}`);
 		}
 	}
 

--- a/src/install.ts
+++ b/src/install.ts
@@ -6,7 +6,7 @@ import * as vscode from 'vscode';
 
 export function OpenDownloadPage(): void {
      //Open a browser to the IIS 10 Express download page for them to do it themselves
-     childProcess.exec('start https://www.microsoft.com/en-us/download/details.aspx?id=48264');
+     childProcess.exec('powershell.exe /c start https://www.microsoft.com/en-us/download/details.aspx?id=48264');
 }
 
 export function DoMagicInstall() : void {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -32,8 +32,8 @@ export function getSettings():Isettings{
     // *******************************************
     // Checks that iisexpress.json exist
     // *******************************************
-    let settingsFolderPath = vscode.workspace.rootPath + "\\.vscode";
-	let settingsFilePath = settingsFolderPath + "\\iisexpress.json";
+    let settingsFolderPath = vscode.workspace.rootPath + "/.vscode";
+	let settingsFilePath = settingsFolderPath + "/iisexpress.json";
 
     
     //use -> https://www.npmjs.com/package/jsonfile


### PR DESCRIPTION
VS Code allows a project folder to be opened in WSL (https://code.visualstudio.com/docs/remote/wsl).

I made a few changes needed to run IIS-Express-Code in such an environment:
- supported OS check
- detection of IIS installation folder
- opening a website in system default browser

Features have been tested and have been confirmed to work properly both in WSL and in Windows environment.

Installer has not been tested, but should work fine (since `cmd.exe` is in env PATH variable it can be called directly from bash/wsl).