### PR TITLE
EXE paths to IISExpress & AppCmd can be configured

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,31 @@
     ],
     "main": "./out/extension",
     "contributes": {
+        "configuration": {
+            "title": "IIS Express",
+            "properties": {
+                "iisexpress.iisExpressPath" : {
+                    "title": "Path to IISExpress.exe",
+                    "examples": [
+                        "C:\\Program Files\\IIS Express\\iisexpress.exe",
+                        "C:\\Program Files (x86)\\IIS Express\\iisexpress.exe"
+                    ],
+                    "markdownDescription":  "An absolute path to **IISExpress.exe** such as `C:\\Program Files\\IIS Express\\iisexpress.exe`",
+                    "default": null,
+                    "type": ["string", "null"]
+                },
+                "iisexpress.appcmdPath" : {
+                    "title": "Path to AppCmd.exe",
+                    "examples": [
+                        "C:\\Program Files\\IIS Express\\appcmd.exe",
+                        "C:\\Program Files (x86)\\IIS Express\\appcmd.exe"
+                    ],
+                    "markdownDescription":  "An absolute path to **appcmd.exe** such as `C:\\Program Files\\IIS Express\\appcmd.exe`",
+                    "default": null,
+                    "type": ["string","null"]
+                }
+            }
+        },
         "commands": [
             {
                 "command": "extension.iis-express.start",

--- a/src/IISExpress.ts
+++ b/src/IISExpress.ts
@@ -14,9 +14,6 @@ export interface IExpressArguments {
 	protocol?: settings.protocolType;
 }
 
-// TODO:
-// * Tidy up code - remove events we do not need
-
 export class IIS {
 	private _iisProcess!: process.ChildProcessWithoutNullStreams;
 	private _iisPath: string;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,10 +14,10 @@ export function activate(context: vscode.ExtensionContext) {
 
 
 	//Registering a command so we can assign a direct keybinding to it (without opening quick launch)
-	var startSite = vscode.commands.registerCommand('extension.iis-express.start',() => {
+	var startSite = vscode.commands.registerCommand('extension.iis-express.start',async () => {
 
 		//Begin checks of OS, IISExpress location etc..
-		let verification = verify.checkForProblems();
+		let verification = await verify.checkForProblems();
 
 		//IISExpress command line arguments
 		let args: iis.IExpressArguments = {
@@ -38,10 +38,10 @@ export function activate(context: vscode.ExtensionContext) {
 	});
 
 	//Registering a command so we can assign a direct keybinding to it (without opening quick launch)
-	var stopSite = vscode.commands.registerCommand('extension.iis-express.stop',() => {
+	var stopSite = vscode.commands.registerCommand('extension.iis-express.stop',async () => {
 
 		//Begin checks of OS, IISExpress location etc..
-		let verification = verify.checkForProblems();
+		let verification = await verify.checkForProblems();
 
 		 //Stop extension from running if we did not pass checks
         if(!verification || !verification.isValidOS || !verification.folderIsOpen || !verification.iisExists){
@@ -60,10 +60,10 @@ export function activate(context: vscode.ExtensionContext) {
 	});
 
 	//Registering a command so we can assign a direct keybinding to it (without opening quick launch)
-	var openSite = vscode.commands.registerCommand('extension.iis-express.open',() => {
+	var openSite = vscode.commands.registerCommand('extension.iis-express.open', async () => {
 
 		//Begin checks of OS, IISExpress location etc..
-		let verification = verify.checkForProblems();
+		let verification = await verify.checkForProblems();
 
 		 //Stop extension from running if we did not pass checks
         if(!verification || !verification.isValidOS || !verification.folderIsOpen || !verification.iisExists){
@@ -83,10 +83,10 @@ export function activate(context: vscode.ExtensionContext) {
 	});
 
     //Registering a command so we can assign a direct keybinding to it (without opening quick launch)
-	var restartSite = vscode.commands.registerCommand('extension.iis-express.restart',() => {
+	var restartSite = vscode.commands.registerCommand('extension.iis-express.restart',async () => {
 
 		//Begin checks of OS, IISExpress location etc..
-		let verification = verify.checkForProblems();
+		let verification = await verify.checkForProblems();
 
 		 //Stop extension from running if we did not pass checks
         if(!verification || !verification.isValidOS || !verification.folderIsOpen || !verification.iisExists){

--- a/src/verification.ts
+++ b/src/verification.ts
@@ -14,7 +14,7 @@ interface verification {
 }
 
 
-export function checkForProblems():verification{
+export async function checkForProblems():Promise<verification>{
 
     //Give some default values
     let results:verification = {
@@ -30,7 +30,8 @@ export function checkForProblems():verification{
     // *******************************************
 
 	//Type = 'WINDOWS_NT'
-	let operatingSystem = os.type();
+    let operatingSystem = os.type();
+
 
 	//Uppercase string to ensure we match correctly
 	operatingSystem = operatingSystem.toUpperCase();
@@ -74,59 +75,100 @@ export function checkForProblems():verification{
     // Verify IIS Express excutable Exists
     // *******************************************
 
-    //Let's check for two folder locations for IISExpress
-	//64bit machines - 'C:\Program Files\IIS Express\iisexpress.exe'
-	//32bit machines - 'C:\Program Files (x86)\IIS Express\iisexpress.exe'
 
-	//'C:\Program Files (x86)'
-	let programFilesPath = <string>process.env.ProgramFiles;
-    let iisPath = null;
 
-	//Try to find IISExpress excutable - build up path to EXE
-	iisPath = path.join(programFilesPath, 'IIS Express', 'iisexpress.exe');
 
-    try {
-        //Check if we can find the file path (get stat info on it)
-        fs.statSync(iisPath);
+    const iisPath = await getConfigValue('iisexpress.iisExpressPath', 'iisexpress.exe');
+    const appCmdPath = await getConfigValue('iisexpress.appcmdPath', 'appcmd.exe');
 
+    if(iisPath !== null && appCmdPath !== null){
         results.iisExists = true;
         results.programPath = iisPath;
-        results.appCmdProgramPath = path.join(programFilesPath, 'IIS Express', 'appcmd.exe');
+        results.appCmdProgramPath = appCmdPath;
+
+        return results;
     }
-    catch (err) {
-       	//ENOENT - File or folder not found
-		if(err && err.code.toUpperCase() === 'ENOENT'){
-            //Prompt user - so they opt in to installing IIS Express
-            vscode.window.showWarningMessage(`We could not find IIS Express at ${iisPath}, would you like us to install it for you?`, 'Yes Please', 'No Thanks').then(selection => {
-                switch(selection){
-                    case 'Yes Please':
-                        //Kick in to auto-pilot
-                        install.DoMagicInstall();
-                        break;
 
-                    case 'No Thanks':
-                        //Open a browser to the IIS 10 Express download page for them to do it themselves
-                        install.OpenDownloadPage();
-                        break;
+    //Prompt user - so they opt in to installing IIS Express
+    vscode.window.showWarningMessage(`We could not find IIS Express. Would you like us to install it for you?`, 'Yes Please', 'No Thanks').then(selection => {
+        switch(selection){
+            case 'Yes Please':
+                // Kick in to auto-pilot
+                install.DoMagicInstall();
+                break;
 
-                    default:
-                        //Do nothing for now (Assume they clicked close on message)
-                }
-            });
+            case 'No Thanks':
+                // Open a browser to the IIS 10 Express download page for them to do it themselves
+                install.OpenDownloadPage();
+                break;
 
+            default:
+                // Do nothing for now (Assume they clicked close on message)
         }
-		else if(err){
-			//Some other error - maybe file permission or ...?
-			vscode.window.showErrorMessage(`There was an error trying to find IISExpress.exe at ${iisPath} due to ${err.message}`);
-		}
+    });
+
+    results.iisExists = false;
+    results.programPath = '';
+    results.appCmdProgramPath = '';
+
+    return results;
+}
 
 
-        results.iisExists = false;
-        results.programPath = "";
+async function getConfigValue(configKey:string, fileName:string):Promise<string | null> {
+    const config = vscode.workspace.getConfiguration();
+    let configValue = <string>config.get(configKey);
+
+    // It's null or an empty string
+    if(configValue === null || configValue.length === 0){
+        // Go and attempt to get it based on convetion from program path
+
+        // Let's check for two folder locations for IISExpress
+        // 64bit machines - 'C:\Program Files\IIS Express\iisexpress.exe'
+        // 32bit machines - 'C:\Program Files (x86)\IIS Express\iisexpress.exe'
+
+        // 'C:\Program Files (x86)' or 'C:\Program Files\'
+        const programFilesPath = <string>process.env.ProgramFiles;
+
+        // Try to find IISExpress excutable - build up path to EXE
+        const conventionFilePath = path.join(programFilesPath, 'IIS Express', fileName);
+
+        // Verify we can find the exe on disk
+        try {
+            // Check if we can find the file path (get stat info on it)
+            fs.statSync(conventionFilePath);
+
+            // Add the convetion path to global config
+            // So we can fetch from config next time
+            await config.update(configKey, conventionFilePath, vscode.ConfigurationTarget.Global);
+
+            // Return the path we found
+            return conventionFilePath;
+        }
+        catch {
+            // In the case of trying to find the convention path
+            // We may not have it installed at all so we need to offer to auto install it
+            return null;
+        }
     }
 
+    // Check if value in config path ends with filename
+    if(configValue.endsWith(fileName) === false){
+        await vscode.window.showErrorMessage(`Please check your VSCode Global configuration for ${configKey} as the path does not end with ${fileName}`, { modal: true });
+        return null;
+    }
 
-    //Return an object back from verifications
-    return results;
-
+    // We have a value set in the config
+    // Try and verify its existance
+    try{
+         // Check if we can find the file path (get stat info on it)
+         fs.statSync(configValue);
+         return configValue;
+    }
+    catch {
+        // User has definied or changed the config key and we are unable to find the file at that location
+        // Lets show an error
+        await vscode.window.showErrorMessage(`Unable to find ${fileName} at the location ${configValue} set in ${configKey} configuration key`, { modal: true });
+        return null;
+    }
 }

--- a/src/verification.ts
+++ b/src/verification.ts
@@ -138,10 +138,6 @@ async function getConfigValue(configKey:string, fileName:string):Promise<string 
             // Check if we can find the file path (get stat info on it)
             fs.statSync(conventionFilePath);
 
-            // Add the convetion path to global config
-            // So we can fetch from config next time
-            await config.update(configKey, conventionFilePath, vscode.ConfigurationTarget.Global);
-
             // Return the path we found
             return conventionFilePath;
         }

--- a/src/verification.ts
+++ b/src/verification.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import * as vscode from 'vscode';
 import * as install from './install';
 
+const TRY_INSTALL_IIS = "TRY_INSTALL_IIS";
 
 interface verification {
     isValidOS: boolean;
@@ -89,23 +90,25 @@ export async function checkForProblems():Promise<verification>{
         return results;
     }
 
-    //Prompt user - so they opt in to installing IIS Express
-    vscode.window.showWarningMessage(`We could not find IIS Express. Would you like us to install it for you?`, 'Yes Please', 'No Thanks').then(selection => {
-        switch(selection){
-            case 'Yes Please':
-                // Kick in to auto-pilot
-                install.DoMagicInstall();
-                break;
+    if(iisPath === TRY_INSTALL_IIS|| appCmdPath === TRY_INSTALL_IIS){
+        //Prompt user - so they opt in to installing IIS Express
+        vscode.window.showWarningMessage(`We could not find IIS Express. Would you like us to install it for you?`, 'Yes Please', 'No Thanks').then(selection => {
+            switch(selection){
+                case 'Yes Please':
+                    // Kick in to auto-pilot
+                    install.DoMagicInstall();
+                    break;
 
-            case 'No Thanks':
-                // Open a browser to the IIS 10 Express download page for them to do it themselves
-                install.OpenDownloadPage();
-                break;
+                case 'No Thanks':
+                    // Open a browser to the IIS 10 Express download page for them to do it themselves
+                    install.OpenDownloadPage();
+                    break;
 
-            default:
-                // Do nothing for now (Assume they clicked close on message)
-        }
-    });
+                default:
+                    // Do nothing for now (Assume they clicked close on message)
+            }
+        });
+    }
 
     results.iisExists = false;
     results.programPath = '';
@@ -144,7 +147,7 @@ async function getConfigValue(configKey:string, fileName:string):Promise<string 
         catch {
             // In the case of trying to find the convention path
             // We may not have it installed at all so we need to offer to auto install it
-            return null;
+            return TRY_INSTALL_IIS;
         }
     }
 


### PR DESCRIPTION
Adds two new config keys to allow you to override the paths of where IISExpress.exe & appcmd.exe are run from

## Configuration Values
```
"iisexpress.iisExpressPath": "C:\\Program Files\\IIS Express\\iisexpress.exe",
"iisexpress.appcmdPath": "C:\\Program Files\\IIS Express\\appcmd.exe",
```

## No Config Values
* No config values set (Global user or Workspace config)
* Try to find IIS Express as default convention of Program Files from environment variable
* If no IIS Express found at convention path - prompt user if they want to install it

## Config Values defined
* Verify the configuration value ends with iisexpress.exe or appcmd.exe otherwise show error
* Verify the configuration value can find the file on disk otherwise show error
* Do not prompt user to auto install so user can fix up their configuration values
