### PR TITLE
Adds new config option iisexpress.openInBrowser to specify which browser to use with auto launch

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,13 @@
                     "markdownDescription":  "An option to disable or enable the browser from launching the site when IIS Express starts. By default this is **true**",
                     "default": true,
                     "type": "boolean"
+                },
+                "iisexpress.openInBrowser": {
+                    "title": "Open in browser",
+                    "markdownDescription": "Decide which browser to auto launch the site with when `iisexpress.autoLaunchBrowser` is set to **true**",
+                    "markdownEnumDescriptions": ["Open in `Default Browser`", "Open in `Chrome`", "Open in `Edge`", "Open in `Firefox`", "Open in `Opera`"],
+                    "enum": ["default", "chrome", "msedge", "firefox", "opera"],
+                    "default": "default"
                 }
             }
         },

--- a/src/IISExpress.ts
+++ b/src/IISExpress.ts
@@ -176,15 +176,19 @@ export class IIS {
 	}
 
 	public openWebsite(options?: settings.Isettings){
+
+		let browserConfig = vscode.workspace.getConfiguration().get<string>("iisexpress.openInBrowser", "default");
+		let browser:string = browserConfig.toLocaleLowerCase() === "default" ? "" : browserConfig;
+
 		if (options && options.url) {
 			// We have a starting URL set - but lets ensure we strip starting / if present
 			let startUrl = options.url.startsWith('/') ? options.url.substring(1) : options.url;
 
 			// Start browser with start url
-			process.exec(`start ${this._args.protocol}://localhost:${this._args.port}/${startUrl}`);
+			process.exec(`start ${browser} ${this._args.protocol}://localhost:${this._args.port}/${startUrl}`);
     	} else {
 			// Uses the 'start' command & url to open default browser
-			process.exec(`start ${this._args.protocol}://localhost:${this._args.port}`);
+			process.exec(`start ${browser} ${this._args.protocol}://localhost:${this._args.port}`);
 		}
 	}
 


### PR DESCRIPTION
This adds a new config option `iisexpress.openInBrowser` which is an enum & thus a dropdown in the VSCode settings UI to pick from.

![image](https://user-images.githubusercontent.com/1389894/87090243-8f33a780-c22f-11ea-8954-481874c3ccaf.png)

Current options are

- Default (Windows default browser)
-  Chrome
-  Edge
-  Firefox
-  Opera

Fixes #58 