### PR TITLE
VSLiveShare - Auto shares IIS Express as a shared server in a LiveShare session

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,18 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@microsoft/servicehub-framework": {
+      "version": "2.6.74",
+      "resolved": "https://registry.npmjs.org/@microsoft/servicehub-framework/-/servicehub-framework-2.6.74.tgz",
+      "integrity": "sha512-QJ//zzvxffupIkzupnVbMYY5YDOP+g5FlG6x0Pl7svRyq8pAouiibckJJcZlMtsMypKWwAnVBKb9/sonEOsUxw==",
+      "requires": {
+        "await-semaphore": "^0.1.3",
+        "msgpack-lite": "^0.1.26",
+        "nerdbank-streams": "2.5.60",
+        "strict-event-emitter-types": "^2.0.0",
+        "vscode-jsonrpc": "^4.0.0"
+      }
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -390,6 +402,11 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
+    "await-semaphore": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/await-semaphore/-/await-semaphore-0.1.3.tgz",
+      "integrity": "sha512-d1W2aNSYcz/sxYO4pMGX9vq65qOTu0P800epMud+6cYYX0QcT7zyqcxec3VWzpgvdXo57UWmVbZpLMjX2m1I7Q=="
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -438,6 +455,16 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
+    },
+    "cancellationtoken": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cancellationtoken/-/cancellationtoken-2.0.1.tgz",
+      "integrity": "sha512-FVCOyTdjFtlhOHaF0R7PAOL0btq+dyhXUvIGtvJ7pr4wd4R31mdlX3ODTDaVk5R08+Fm+MSHwGA5BJH99sNYdQ=="
+    },
+    "caught": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/caught/-/caught-0.1.3.tgz",
+      "integrity": "sha512-DTWI84qfoqHEV5jHRpsKNnEisVCeuBDscXXaXyRLXC+4RD6rFftUNuTElcQ7LeO7w622pfzWkA1f6xu5qEAidw=="
     },
     "chalk": {
       "version": "2.4.2",
@@ -1009,6 +1036,11 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "event-lite": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/event-lite/-/event-lite-0.1.2.tgz",
+      "integrity": "sha512-HnSYx1BsJ87/p6swwzv+2v6B4X+uxUteoDfRxsAb1S1BePzQqOLevVmkdA15GHJVd9A9Ok6wygUR18Hu0YeV9g=="
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1227,6 +1259,11 @@
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
     },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -1264,6 +1301,11 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
+    },
+    "int64-buffer": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.1.10.tgz",
+      "integrity": "sha1-J3siiofZWtd30HwTgyAiQGpHNCM="
     },
     "is-arguments": {
       "version": "1.0.4",
@@ -1592,11 +1634,40 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "msgpack-lite": {
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/msgpack-lite/-/msgpack-lite-0.1.26.tgz",
+      "integrity": "sha1-3TxQsm8FnyXn7e42REGDWOKprYk=",
+      "requires": {
+        "event-lite": "^0.1.1",
+        "ieee754": "^1.1.8",
+        "int64-buffer": "^0.1.9",
+        "isarray": "^1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        }
+      }
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "nerdbank-streams": {
+      "version": "2.5.60",
+      "resolved": "https://registry.npmjs.org/nerdbank-streams/-/nerdbank-streams-2.5.60.tgz",
+      "integrity": "sha512-saQaMyTtVDAEc+S+BPXKM6K1AF3FyrorFSDzaCkdmtDe2kZzu1aYPQZNLmnxJhxbTcghYrEmYFFoaDxBDVadCw==",
+      "requires": {
+        "await-semaphore": "^0.1.3",
+        "cancellationtoken": "^2.0.1",
+        "caught": "^0.1.3",
+        "msgpack-lite": "^0.1.26"
+      }
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -2090,6 +2161,11 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "strict-event-emitter-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz",
+      "integrity": "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA=="
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -2288,6 +2364,11 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "vscode-jsonrpc": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz",
+      "integrity": "sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg=="
+    },
     "vscode-test": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.4.0.tgz",
@@ -2297,6 +2378,14 @@
         "http-proxy-agent": "^2.1.0",
         "https-proxy-agent": "^2.2.4",
         "rimraf": "^2.6.3"
+      }
+    },
+    "vsls": {
+      "version": "1.0.2426",
+      "resolved": "https://registry.npmjs.org/vsls/-/vsls-1.0.2426.tgz",
+      "integrity": "sha512-sDDr2BmmT1HhOegokdM9tUlXcNtKAOCoufFNpQ7O7Yr59S9cGaFuBBV2fVu8ri1589WhonrMhlYbuWvFhE8mGw==",
+      "requires": {
+        "@microsoft/servicehub-framework": "^2.6.74"
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -39,37 +39,55 @@
         "configuration": {
             "title": "IIS Express",
             "properties": {
-                "iisexpress.iisExpressPath" : {
+                "iisexpress.iisExpressPath": {
                     "title": "Path to IISExpress.exe",
                     "examples": [
                         "C:\\Program Files\\IIS Express\\iisexpress.exe",
                         "C:\\Program Files (x86)\\IIS Express\\iisexpress.exe"
                     ],
-                    "markdownDescription":  "An absolute path to **IISExpress.exe** such as `C:\\Program Files\\IIS Express\\iisexpress.exe`",
+                    "markdownDescription": "An absolute path to **IISExpress.exe** such as `C:\\Program Files\\IIS Express\\iisexpress.exe`",
                     "default": null,
-                    "type": ["string", "null"]
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 },
-                "iisexpress.appcmdPath" : {
+                "iisexpress.appcmdPath": {
                     "title": "Path to AppCmd.exe",
                     "examples": [
                         "C:\\Program Files\\IIS Express\\appcmd.exe",
                         "C:\\Program Files (x86)\\IIS Express\\appcmd.exe"
                     ],
-                    "markdownDescription":  "An absolute path to **appcmd.exe** such as `C:\\Program Files\\IIS Express\\appcmd.exe`",
+                    "markdownDescription": "An absolute path to **appcmd.exe** such as `C:\\Program Files\\IIS Express\\appcmd.exe`",
                     "default": null,
-                    "type": ["string","null"]
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 },
-                "iisexpress.autoLaunchBrowser" : {
+                "iisexpress.autoLaunchBrowser": {
                     "title": "Auto launch browser",
-                    "markdownDescription":  "An option to disable or enable the browser from launching the site when IIS Express starts. By default this is **true**",
+                    "markdownDescription": "An option to disable or enable the browser from launching the site when IIS Express starts. By default this is **true**",
                     "default": true,
                     "type": "boolean"
                 },
                 "iisexpress.openInBrowser": {
                     "title": "Open in browser",
                     "markdownDescription": "Decide which browser to auto launch the site with when `iisexpress.autoLaunchBrowser` is set to **true**",
-                    "markdownEnumDescriptions": ["Open in `Default Browser`", "Open in `Chrome`", "Open in `Edge`", "Open in `Firefox`", "Open in `Opera`"],
-                    "enum": ["default", "chrome", "msedge", "firefox", "opera"],
+                    "markdownEnumDescriptions": [
+                        "Open in `Default Browser`",
+                        "Open in `Chrome`",
+                        "Open in `Edge`",
+                        "Open in `Firefox`",
+                        "Open in `Opera`"
+                    ],
+                    "enum": [
+                        "default",
+                        "chrome",
+                        "msedge",
+                        "firefox",
+                        "opera"
+                    ],
                     "default": "default"
                 }
             }
@@ -139,6 +157,7 @@
     "dependencies": {
         "iconv-lite": "^0.6.2",
         "jsonfile": "^6.0.1",
-        "uuid": "^8.2.0"
+        "uuid": "^8.2.0",
+        "vsls": "^1.0.2426"
     }
 }


### PR DESCRIPTION
Adds VSLiveShare extension support - will prompt user to share IIS Server Port when IIS Express starts in a VSLiveShare session

Fixes #96 