### PR TITLE
Add in VSCode custom when context for enabling & disabling commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,31 +96,53 @@
             {
                 "command": "extension.iis-express.start",
                 "title": "Start Website",
-                "category": "IIS Express"
+                "category": "IIS Express",
+                "enablement": "iisexpress:siterunning != true && isWindows"
             },
             {
                 "command": "extension.iis-express.stop",
                 "title": "Stop Website",
-                "category": "IIS Express"
+                "category": "IIS Express",
+                "enablement": "iisexpress:siterunning && isWindows"
             },
             {
                 "command": "extension.iis-express.restart",
                 "title": "Restart Website",
-                "category": "IIS Express"
+                "category": "IIS Express",
+                "enablement": "iisexpress:siterunning && isWindows"
             }
         ],
+        "menus": {
+            "commandPalette": [
+                {
+                    "command": "extension.iis-express.start",
+                    "when": "iisexpress:siterunning != true && isWindows"
+                },
+                {
+                    "command": "extension.iis-express.stop",
+                    "when": "iisexpress:siterunning && isWindows"
+                },
+                {
+                    "command": "extension.iis-express.restart",
+                    "when": "iisexpress:siterunning && isWindows"
+                }
+            ]
+        },
         "keybindings": [
             {
                 "command": "extension.iis-express.start",
+                "when": "iisexpress:siterunning != true && isWindows",
                 "key": "ctrl+f5"
             },
             {
                 "command": "extension.iis-express.stop",
-                "key": "shift+f5"
+                "key": "shift+f5",
+                "when": "iisexpress:siterunning && isWindows"
             },
             {
                 "command": "extension.iis-express.restart",
-                "key": "ctrl+shift+f5"
+                "key": "ctrl+shift+f5",
+                "when": "iisexpress:siterunning && isWindows"
             }
         ],
         "jsonValidation": [

--- a/src/IISExpress.ts
+++ b/src/IISExpress.ts
@@ -115,6 +115,9 @@ export class IISExpress {
 			this.openWebsite(options);
 		}
 
+		// Used to enable/disable commands & to know when a site is running
+		vscode.commands.executeCommand('setContext', 'iisexpress:siterunning', true);
+
 		// Attach all the events & functions to iisProcess
 		this._iisProcess.stdout.on('data', (data: string) =>{
 			data = this.decode2gbk(data);
@@ -161,6 +164,9 @@ export class IISExpress {
 
 		// Kill the process - which will also hook into the exit event to remove the config entry
 		this._iisProcess.kill('SIGINT');
+
+		// Used to enable/disable commands & to know when a site is running
+		vscode.commands.executeCommand('setContext', 'iisexpress:siterunning', false);
 
 		// Clear the output log
 		this._output!.clear();


### PR DESCRIPTION
This now only shows the IIS Express Start Website command in the command pallete when no active site is running & thus the inverse as well. Where only the Stop & Restart commands are shown/active when a site is running.