### PR TITLE
Custom IIS Express View in Explorer for easier access to commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
         "onCommand:extension.iis-express.start",
         "onCommand:extension.iis-express.stop",
         "onCommand:extension.iis-express.open",
-        "onCommand:extension.iis-express.restart"
+        "onCommand:extension.iis-express.restart",
+        "onView:iisexpress.controls"
     ],
     "main": "./out/extension",
     "contributes": {
@@ -97,19 +98,29 @@
                 "command": "extension.iis-express.start",
                 "title": "Start Website",
                 "category": "IIS Express",
-                "enablement": "iisexpress:siterunning != true && isWindows"
+                "enablement": "iisexpress:siterunning != true && isWindows",
+                "icon": "$(play)"
             },
             {
                 "command": "extension.iis-express.stop",
                 "title": "Stop Website",
                 "category": "IIS Express",
-                "enablement": "iisexpress:siterunning && isWindows"
+                "enablement": "iisexpress:siterunning && isWindows",
+                "icon": "$(stop)"
             },
             {
                 "command": "extension.iis-express.restart",
                 "title": "Restart Website",
                 "category": "IIS Express",
-                "enablement": "iisexpress:siterunning && isWindows"
+                "enablement": "iisexpress:siterunning && isWindows",
+                "icon": "$(refresh)"
+            },
+            {
+                "command": "extension.iis-express.supporter",
+                "title": "Become a supporter",
+                "category": "IIS Express",
+                "enablement": "isWindows",
+                "icon" : "$(heart)"
             }
         ],
         "menus": {
@@ -125,6 +136,20 @@
                 {
                     "command": "extension.iis-express.restart",
                     "when": "iisexpress:siterunning && isWindows"
+                }
+            ],
+            "view/title": [
+                {
+                    "command": "extension.iis-express.start",
+                    "group": "navigation@10"
+                },
+                {
+                    "command": "extension.iis-express.restart",
+                    "group": "navigation@11"
+                },
+                {
+                    "command": "extension.iis-express.stop",
+                    "group": "navigation@12"
                 }
             ]
         },
@@ -145,6 +170,16 @@
                 "when": "iisexpress:siterunning && isWindows"
             }
         ],
+        "views": {
+            "explorer": [
+                {
+                    "id": "iisexpress.controls",
+                    "contextualTitle": "IIS Express",
+                    "name": "IIS Express",
+                    "when": "isWindows"
+                }
+            ]
+        },
         "jsonValidation": [
             {
                 "fileMatch": "/.vscode/iisexpress.json",

--- a/package.json
+++ b/package.json
@@ -121,6 +121,13 @@
                 "category": "IIS Express",
                 "enablement": "isWindows",
                 "icon" : "$(heart)"
+            },
+            {
+                "command": "extension.iis-express.settings",
+                "title": "Open Settings",
+                "category": "IIS Express",
+                "enablement": "isWindows",
+                "icon" : "$(settings-gear)"
             }
         ],
         "menus": {
@@ -140,16 +147,9 @@
             ],
             "view/title": [
                 {
-                    "command": "extension.iis-express.start",
-                    "group": "navigation@10"
-                },
-                {
-                    "command": "extension.iis-express.restart",
-                    "group": "navigation@11"
-                },
-                {
-                    "command": "extension.iis-express.stop",
-                    "group": "navigation@12"
+                    "command": "extension.iis-express.settings",
+                    "group": "navigation@1",
+                    "when": "isWindows && view == iisexpress.controls"
                 }
             ]
         },

--- a/src/ControlsTreeProvider.ts
+++ b/src/ControlsTreeProvider.ts
@@ -1,0 +1,60 @@
+import * as vscode from 'vscode';
+
+export class ControlsTreeProvider implements vscode.TreeDataProvider<ControlsTreeItem> {
+
+
+    onDidChangeTreeData?: vscode.Event<void | ControlsTreeItem | null | undefined> | undefined;
+
+    getTreeItem(element: ControlsTreeItem): vscode.TreeItem | Thenable<vscode.TreeItem> {
+        return element;
+    }
+
+    getChildren(element?: ControlsTreeItem | undefined): vscode.ProviderResult<ControlsTreeItem[]> {
+        if(element === undefined){
+            const items = new Array<ControlsTreeItem>();
+            items.push(
+                {
+                    label: 'Start Website',
+                    iconPath: new vscode.ThemeIcon("play"),
+                    collapsibleState: vscode.TreeItemCollapsibleState.None,
+                    command: {
+                        title: 'Start Website',
+                        command: "extension.iis-express.start"
+                    }
+                },
+                {
+                    label: 'Restart Website',
+                    iconPath: new vscode.ThemeIcon("refresh"),
+                    collapsibleState: vscode.TreeItemCollapsibleState.None,
+                    command: {
+                        title: 'Restart Website',
+                        command: "extension.iis-express.restart"
+                    }
+                },
+                {
+                    label: 'Stop Website',
+                    iconPath: new vscode.ThemeIcon("stop"),
+                    collapsibleState: vscode.TreeItemCollapsibleState.None,
+                    command: {
+                        title: 'Stop Website',
+                        command: "extension.iis-express.stop"
+                    }
+                },
+                {
+                    label: 'Become a supporter',
+                    iconPath: new vscode.ThemeIcon("heart"),
+                    collapsibleState: vscode.TreeItemCollapsibleState.None,
+                    command: {
+                        title: 'Become a supporter',
+                        command: 'extension.iis-express.supporter'
+                    }
+                });
+
+            return items;
+        }
+
+        return Promise.resolve([]);
+    }
+}
+
+export class ControlsTreeItem extends vscode.TreeItem {}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,8 @@ import * as verify from './verification';
 import * as settings from './settings';
 
 import * as vsls from 'vsls';
+import { ControlsTreeProvider } from './ControlsTreeProvider';
+// import { ControlsTreeProvider } from './ControlsTreeProvider';
 
 let iisExpressServer:iis.IISExpress;
 
@@ -17,6 +19,11 @@ export async function activate(context: vscode.ExtensionContext) {
 	// If not then this will be null
 	const liveshare = await vsls.getApi();
 	let liveShareServer:vscode.Disposable;
+
+	// Register tree provider to put our custom commands into the tree
+	// Start, Stop, Restart, Support etc...
+	const controlsTreeProvider = new ControlsTreeProvider();
+	vscode.window.registerTreeDataProvider('iisexpress.controls', controlsTreeProvider);
 
 	// Begin checks of OS, IISExpress location etc..
 	const verification = await verify.checkForProblems();
@@ -99,8 +106,12 @@ export async function activate(context: vscode.ExtensionContext) {
 		iisExpressServer.restartSite(settings.getSettings());
 	});
 
+	const supporter = vscode.commands.registerCommand('extension.iis-express.supporter',async () => {
+		vscode.env.openExternal(vscode.Uri.parse("http://github.com/sponsors/warrenbuckley"));
+	});
+
 	// Push the commands & any other VSCode disposables
-	context.subscriptions.push(startSite, stopSite, openSite, restartSite);
+	context.subscriptions.push(startSite, stopSite, openSite, restartSite, supporter);
 }
 
 // this method is called when your extension is deactivated

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -110,8 +110,13 @@ export async function activate(context: vscode.ExtensionContext) {
 		vscode.env.openExternal(vscode.Uri.parse("http://github.com/sponsors/warrenbuckley"));
 	});
 
+	const openSettings = vscode.commands.registerCommand('extension.iis-express.settings',async () => {
+		// 'workbench.action.openSettings' argument is search query to only show our settings to filter out other settings
+		vscode.commands.executeCommand('workbench.action.openSettings', '@ext:warren-buckley.iis-express');
+	});
+
 	// Push the commands & any other VSCode disposables
-	context.subscriptions.push(startSite, stopSite, openSite, restartSite, supporter);
+	context.subscriptions.push(startSite, stopSite, openSite, restartSite, supporter, openSettings);
 }
 
 // this method is called when your extension is deactivated


### PR DESCRIPTION
This adds a nice custom view to the explorer section by default, but as VSCode allows you to customise this it can be dragged & dropped to a new location or even it's own section if preferred by the user.

Adds two new commands:
* Become a supporter - opens GitHub Sponsors page
* Open Settings - open settings editor with a filter applied to only show our IIS Express extension settings

![image](https://user-images.githubusercontent.com/1389894/87935547-37940800-ca89-11ea-9b29-a47991231358.png)

![image](https://user-images.githubusercontent.com/1389894/87935378-e7b54100-ca88-11ea-88a5-6d1fc50289be.png)
