### PR TITLE
Support for relative paths for the site folder to run in iisexpress.json config file

### DIFF
--- a/src/iisexpress-schema.json
+++ b/src/iisexpress-schema.json
@@ -25,7 +25,7 @@
         },
         "path": {
             "type": "string",
-            "description": "This property is optional & allows you to set a path to the folder or subfolder as the root of your site/project for IIS Express to run"
+            "description": "This property is optional & allows you to set an absolute path to the folder or subfolder as the root of your site/project for IIS Express to run. Additionally this support relative paths to the workspace folder such as ./my-sub-folder"
         },
         "url": {
             "type": "string",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -24,7 +24,7 @@ export function getSettings():Isettings{
     // Give some default values
     let defaultSettings:Isettings = {
         port : getRandomPort(),
-        path: vscode.workspace.rootPath as string,
+        path: './',
         clr: clrVersion.v40,
         protocol: protocolType.http
     };


### PR DESCRIPTION
Support for relative path for the site folder to run in IIS Express config defaults to ./
Fixes #25 

## Behaviour
* New .vscode/iisexpress.json files created will now default to a relative path of .`/`
* Existing full absolute paths will continue to work
* Removing the path property/value in the `.vscode/iisexpress.json` file will default to the workspace root  folder
* Relative paths such as `./some-sub-folder` will work
* Checks folder exists & prompts user with error if it does not - as a user could create a relative path that does not exist such as `../looking-for-non-existant-parent` or `/some-c-drive-root-folder`