### PR TITLE
Improve telemetry

### DIFF
--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -39,6 +39,7 @@ export class Credentials {
 
 			// Used to enable/disable the GitHub Login command & to know when user has auth'd
 			vscode.commands.executeCommand('setContext', 'iisexpress:userIsLoggedIn', true);
+			this.reporter?.sendTelemetryEvent('github.loggedin');
 			return;
 		}
 
@@ -47,6 +48,7 @@ export class Credentials {
 
 		// Used to enable/disable the GitHub Login command & to know when user has auth'd
 		vscode.commands.executeCommand('setContext', 'iisexpress:userIsLoggedIn', false);
+		this.reporter?.sendTelemetryEvent('github.loggedout');
 	}
 
 	private registerListeners(): void {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -44,7 +44,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	// Init credentials class with event listener & prompt/get token from GitHub auth
 	const credentials = new Credentials(context, reporter);
-	const sponsorware = new Sponsorware(context, credentials);
+	const sponsorware = new Sponsorware(context, credentials, reporter);
 
 	// Register tree provider to put our custom commands into the tree
 	// Start, Stop, Restart, Support etc...

--- a/src/sponsorware.ts
+++ b/src/sponsorware.ts
@@ -1,16 +1,19 @@
 import * as vscode from 'vscode';
 import path = require('path');
 import { Credentials } from './credentials';
+import TelemetryReporter from 'vscode-extension-telemetry';
 
 export class Sponsorware {
 
     private context: vscode.ExtensionContext;
     private totalCount:number = 0;
     private credentials: Credentials;
+    private reporter: TelemetryReporter;
 
-    constructor(context: vscode.ExtensionContext, credentials:Credentials) {
+    constructor(context: vscode.ExtensionContext, credentials:Credentials, reporter:TelemetryReporter) {
         this.context = context;
         this.credentials = credentials;
+        this.reporter = reporter;
     }
 
     private async doWeShowSponsorMessagePanel():Promise<boolean> {
@@ -118,6 +121,10 @@ export class Sponsorware {
         if(await this.doWeShowSponsorMessagePanel() === false){
             return;
         }
+
+        // Send telmetry event - so we know how many times this is being shown
+        this.reporter.sendTelemetryEvent('sponsorware.displayed', {}, { 'totalCount': this.totalCount });
+
 
         // Create and show a new webview
         const panel = vscode.window.createWebviewPanel(

--- a/src/sponsorware.ts
+++ b/src/sponsorware.ts
@@ -90,7 +90,7 @@ export class Sponsorware {
             <p>Becoming a sponsor removes this sponsorware message and you get a warm fuzzy feeling for supporting an individual.</p>
 
             <p>
-                <a href="https://github.com/sponsors/warrenbuckley"
+                <a href="command:extension.iis-express.supporter"
                     class="button"
                     role="button"
                     title="Sponsor Warren Buckley">Sponsor Warren Buckley on GitHub</a>


### PR DESCRIPTION
This improves telemetry now the 1.2.0 release has been out for a couple of weeks and looking into the metrics, I did not implement an telemetry event for when the sponsorware message is shown.

This gives me an idea of who is being shown the sponsorware message and from this I will be able to see how often people see this & dismiss it