### PR TITLE
Support for multi folder workspaces

### DIFF
--- a/src/IISExpress.ts
+++ b/src/IISExpress.ts
@@ -36,7 +36,7 @@ export class IISExpress {
 		this._reporter = reporter;
 	}
 
-	public startWebsite(options: settings.Isettings) {
+	public startWebsite(options: settings.Isettings, workspaceFolder: vscode.Uri) {
 
 		// Verify process not already running, so if we have a PID (process ID) it's running
 		if(this._iisProcess !== undefined && this._iisProcess.killed === false){
@@ -59,7 +59,7 @@ export class IISExpress {
 			port: options.port,
 
 			// Folder to run as the arg
-			path: options.path ? options.path : <string>vscode.workspace.rootPath,
+			path: options.path ? options.path : workspaceFolder.fsPath,
 
 			// CLR version, yes there are still people on 3.5 & default back to v4 if not set
 			clr: options.clr ? options.clr : settings.clrVersion.v40,
@@ -74,7 +74,7 @@ export class IISExpress {
 		// It may also include the legacy full path of the workspace rootpath
 		// Which caused issues - when checked into source control & other users did not have same folder structure
 		// or if you moved the folder on your own machine - it would no longer map correctly
-		const resolvedPath = path.resolve(<string>vscode.workspace.rootPath, this._args.path);
+		const resolvedPath = path.resolve(workspaceFolder.fsPath, this._args.path);
 		this._args.path = resolvedPath;
 
 		// Verify folder exists on disk (in case relative path used & selected wrong thing)
@@ -91,7 +91,7 @@ export class IISExpress {
 
 		// Site name is the name of the workspace folder & GUID/UUID
 		// Need to append a UUID as could have two folders/sites with same name
-		const siteName = path.basename(vscode.workspace.rootPath as string) + "-" + uuidv4();
+		const siteName = path.basename(workspaceFolder.fsPath as string) + "-" + uuidv4();
 
 		// If user is using HTTPS & port not in range of auto-approved port numbers (44300-44399)
 		// Then display an error & stop process
@@ -236,16 +236,16 @@ export class IISExpress {
 		}
 	}
 
-	public restartSite(options : settings.Isettings){
+	public restartSite(options : settings.Isettings, workspaceFolder: vscode.Uri){
 		// If we do not have an iisProcess/website running
 		if(!this._iisProcess){
 			// Then just do a start site...
-			this.startWebsite(options);
+			this.startWebsite(options, workspaceFolder);
 		}
 		else {
 			// It's already running so stop it first then, start it
 			this.stopWebsite();
-			this.startWebsite(options);
+			this.startWebsite(options, workspaceFolder);
 		}
 
 		// Log telemtry

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,6 +29,9 @@ const key = 'e0cc903f-73ec-4216-92cd-3479696785b2';
 // create telemetry reporter on extension activation
 const reporter:TelemetryReporter = new TelemetryReporter(extensionId, extensionVersion, key);
 
+
+let vsCodeFolderToRun:vscode.Uri | undefined = undefined;
+
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export async function activate(context: vscode.ExtensionContext) {
@@ -67,16 +70,18 @@ export async function activate(context: vscode.ExtensionContext) {
 		// Will auto get single folder or let user choose single folder from multi-workspace folders
 		settings.getFolder().then(async folderToRun => {
 
+			vsCodeFolderToRun = folderToRun;
+
 			// Exit out early
-			if(folderToRun === undefined){
+			if(vsCodeFolderToRun === undefined){
 				return;
 			}
 
 			// Start Website...
 			// Pass settings - just in case its changed between session
 			// GetSettings now takes new param of workspace folder URI to use
-			const serverSettings = settings.getSettings(folderToRun);
-			await iisExpressServer.startWebsite(serverSettings, folderToRun);
+			const serverSettings = settings.getSettings(vsCodeFolderToRun);
+			await iisExpressServer.startWebsite(serverSettings, vsCodeFolderToRun);
 
 			// Checks if we need to display sponsorware webview message
 			await sponsorware.showSponsorMessagePanel();
@@ -105,7 +110,9 @@ export async function activate(context: vscode.ExtensionContext) {
         if(!verification || !verification.isValidOS || !verification.folderIsOpen || !verification.iisExists){
             // Stop the extension from running
             return;
-        }
+		}
+		
+		vsCodeFolderToRun = undefined;
 
 		// Stop Website...
 		iisExpressServer.stopWebsite();
@@ -128,21 +135,17 @@ export async function activate(context: vscode.ExtensionContext) {
             return;
 		}
 
-		// Will auto get single folder or let user choose single folder from multi-workspace folders
-		settings.getFolder().then(async folderToRun => {
+		// Exit out early
+		if(vsCodeFolderToRun === undefined){
+			return;
+		}
 
-			// Exit out early
-			if(folderToRun === undefined){
-				return;
-			}
-
-			// GetSettings now takes new param of workspace folder URI to use
-			const serverSettings = settings.getSettings(folderToRun);
+		// GetSettings now takes new param of workspace folder URI to use
+		const serverSettings = settings.getSettings(vsCodeFolderToRun);
 			
-			// Open site in browser - this will need to check if site is running first...
-			// Pass settings - just in case its changed between session (Hence not set globally in this file)
-			iisExpressServer.openWebsite(serverSettings);
-		});
+		// Open site in browser - this will need to check if site is running first...
+		// Pass settings - just in case its changed between session (Hence not set globally in this file)
+		iisExpressServer.openWebsite(serverSettings);
 	});
 
     // Registering a command so we can assign a direct keybinding to it (without opening quick launch)
@@ -154,21 +157,17 @@ export async function activate(context: vscode.ExtensionContext) {
             return;
 		}
 
-		// Will auto get single folder or let user choose single folder from multi-workspace folders
-		settings.getFolder().then(async folderToRun => {
+		// Exit out early
+		if(vsCodeFolderToRun === undefined){
+			return;
+		}
 
-			// Exit out early
-			if(folderToRun === undefined){
-				return;
-			}
-
-			// GetSettings now takes new param of workspace folder URI to use
-			const serverSettings = settings.getSettings(folderToRun);
-			
-			// Restart site  - this will need to check if site is running first...
-			// Pass settings - just in case its changed between session (Hence not set globally in this file)
-			iisExpressServer.restartSite(serverSettings, folderToRun);
-		});
+		// GetSettings now takes new param of workspace folder URI to use
+		const serverSettings = settings.getSettings(vsCodeFolderToRun);
+		
+		// Restart site  - this will need to check if site is running first...
+		// Pass settings - just in case its changed between session (Hence not set globally in this file)
+		iisExpressServer.restartSite(serverSettings, vsCodeFolderToRun);
 
 		// Checks if we need to display sponsoware webview message
 		await sponsorware.showSponsorMessagePanel();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -64,26 +64,38 @@ export async function activate(context: vscode.ExtensionContext) {
             return;
         }
 
-		// Start Website...
-		// Pass settings - just in case its changed between session
-		iisExpressServer.startWebsite(settings.getSettings());
+		// Will auto get single folder or let user choose single folder from multi-workspace folders
+		settings.getFolder().then(async folderToRun => {
 
-		// Checks if we need to display sponsoware webview message
-		await sponsorware.showSponsorMessagePanel();
-
-		// Ensure user has liveshare extension
-		if(liveshare !== null){
-			if((liveshare.session.id !== null) && (liveshare.session.role === vsls.Role.Host)){
-				const portNumber = settings.getSettings().port;
-
-				// This will prompt the LiveShare Host to share the IIS Server Port
-				liveShareServer = await liveshare.shareServer({ displayName: `IIS Express:${portNumber}`, port: portNumber });
-
-				// Push the disposable VSCode into the subscriptions
-				// so VSCode can dispose them if we forget to or when the extension is deactivated
-				context.subscriptions.push(liveShareServer);
+			// Exit out early
+			if(folderToRun === undefined){
+				return;
 			}
-		}
+
+			// Start Website...
+			// Pass settings - just in case its changed between session
+			// GetSettings now takes new param of workspace folder URI to use
+			const serverSettings = settings.getSettings(folderToRun);
+			await iisExpressServer.startWebsite(serverSettings, folderToRun);
+
+			// Checks if we need to display sponsorware webview message
+			await sponsorware.showSponsorMessagePanel();
+
+			// Ensure user has liveshare extension
+			if(liveshare !== null){
+				if((liveshare.session.id !== null) && (liveshare.session.role === vsls.Role.Host)){
+					const portNumber = serverSettings.port;
+
+					// This will prompt the LiveShare Host to share the IIS Server Port
+					liveShareServer = await liveshare.shareServer({ displayName: `IIS Express:${portNumber}`, port: portNumber });
+
+					// Push the disposable VSCode into the subscriptions
+					// so VSCode can dispose them if we forget to or when the extension is deactivated
+					context.subscriptions.push(liveShareServer);
+				}
+			}
+		});
+		
 	});
 
 	// Registering a command so we can assign a direct keybinding to it (without opening quick launch)
@@ -116,9 +128,21 @@ export async function activate(context: vscode.ExtensionContext) {
             return;
 		}
 
-		// Open site in browser - this will need to check if site is running first...
-		// Pass settings - just in case its changed between session (Hence not set globally in this file)
-		iisExpressServer.openWebsite(settings.getSettings());
+		// Will auto get single folder or let user choose single folder from multi-workspace folders
+		settings.getFolder().then(async folderToRun => {
+
+			// Exit out early
+			if(folderToRun === undefined){
+				return;
+			}
+
+			// GetSettings now takes new param of workspace folder URI to use
+			const serverSettings = settings.getSettings(folderToRun);
+			
+			// Open site in browser - this will need to check if site is running first...
+			// Pass settings - just in case its changed between session (Hence not set globally in this file)
+			iisExpressServer.openWebsite(serverSettings);
+		});
 	});
 
     // Registering a command so we can assign a direct keybinding to it (without opening quick launch)
@@ -130,9 +154,21 @@ export async function activate(context: vscode.ExtensionContext) {
             return;
 		}
 
-		// Open site in browser - this will need to check if site is running first...
-		// Pass settings - just in case its changed between session (Hence not set globally in this file)
-		iisExpressServer.restartSite(settings.getSettings());
+		// Will auto get single folder or let user choose single folder from multi-workspace folders
+		settings.getFolder().then(async folderToRun => {
+
+			// Exit out early
+			if(folderToRun === undefined){
+				return;
+			}
+
+			// GetSettings now takes new param of workspace folder URI to use
+			const serverSettings = settings.getSettings(folderToRun);
+			
+			// Restart site  - this will need to check if site is running first...
+			// Pass settings - just in case its changed between session (Hence not set globally in this file)
+			iisExpressServer.restartSite(serverSettings, folderToRun);
+		});
 
 		// Checks if we need to display sponsoware webview message
 		await sponsorware.showSponsorMessagePanel();

--- a/src/install.ts
+++ b/src/install.ts
@@ -89,7 +89,8 @@ function InstallTime(installerFilePath:string) : Promise<any> {
         });
 
         installer.on('exit', () => {
-            resolve();
+            // Resolve promise with empty obj
+            resolve({});
         });
     });
 }

--- a/src/verification.ts
+++ b/src/verification.ts
@@ -53,15 +53,11 @@ export async function checkForProblems():Promise<verification>{
     // Checks that VS Code is open with a folder
     // *******************************************
 
-    // Get the path of the folder that is open in VS Code
-    const folderPath = vscode.workspace.rootPath;
-
-
     // Check if we are in a folder/workspace & NOT just have a single file open
-	if(!folderPath){
+	if(vscode.workspace.workspaceFolders === undefined || vscode.workspace.workspaceFolders.length === 0){
 		vscode.window.showErrorMessage('Please open a workspace directory first.');
 
-        // We are not a folder
+        // No folder/s are open (could be more than one if using workspaces)
         results.folderIsOpen = false;
 	}
     else {


### PR DESCRIPTION
This feature adds the following:

- Opening a VSCode Workspace with multiple root folders will prompt to ask which folder to run when starting IIS Express
- If VSCode Workspace has only one root folder then it will continue as before and not prompt you

⚠️ This only allows one folder to be run at a time ⚠️

## Credit

This reimplements the PR #44 from @orjhor to allow a user to pick which folder to run when in a multi-workspace, otherwise if its a single folder it will behave as before.

Fixes #42

All credit for this feature & idea goes to @orjhor and @zmikes for creating the original issue