### PR TITLE
Add support for Classic pipeline mode

### DIFF
--- a/src/IISExpress.ts
+++ b/src/IISExpress.ts
@@ -10,12 +10,12 @@ import { v4 as uuidv4 } from 'uuid';
 import * as iconv from 'iconv-lite';
 import TelemetryReporter from 'vscode-extension-telemetry';
 
-
 export interface IExpressArguments {
 	path: string;
 	port: number;
 	clr: settings.clrVersion;
 	protocol: settings.protocolType;
+	pipelineMode?: settings.pipelineMode; // New property for pipeline mode
 }
 
 export class IISExpress {
@@ -65,7 +65,10 @@ export class IISExpress {
 			clr: options.clr ? options.clr : settings.clrVersion.v40,
 
 			// If no protocol set fallback to http as opposed to https
-			protocol: options.protocol ? options.protocol : settings.protocolType.http
+			protocol: options.protocol ? options.protocol : settings.protocolType.http,
+
+			// Pipeline mode, default to Integrated if not set
+			pipelineMode: options.pipelineMode ? options.pipelineMode : settings.pipelineMode.Integrated
 		};
 
 
@@ -112,8 +115,13 @@ export class IISExpress {
 			this._reporter.sendTelemetryException(error, {"appCmdPath": this._iisAppCmdPath, "appCmd": `add site -name:${siteName} -bindings:${this._args.protocol}://localhost:${this._args.port} -physicalPath:${this._args.path}`});
 		}
 
-		// Based on the CLR chosen use the correct built in AppPools shipping with IISExpress
-		const appPool = this._args.clr === settings.clrVersion.v40 ? "Clr4IntegratedAppPool" : "Clr2IntegratedAppPool";
+		// Determine the application pool based on CLR version and pipeline mode
+		let appPool = "";
+		if (this._args.pipelineMode === settings.pipelineMode.Integrated) {
+			appPool = this._args.clr === settings.clrVersion.v40 ? "Clr4IntegratedAppPool" : "Clr2IntegratedAppPool";
+		} else {
+			appPool = this._args.clr === settings.clrVersion.v40 ? "Clr4ClassicAppPool" : "Clr2ClassicAppPool";
+		}
 
 		// Assign the apppool to the site
 		// appcmd set app /app.name:Site-Staging-201ec232-2906-4052-a431-727ec57b5b2e/ /applicationPool:Clr2IntegratedAppPool

--- a/src/iisexpress-schema.json
+++ b/src/iisexpress-schema.json
@@ -13,6 +13,13 @@
                 "http",
                 "https"
             ]
+        },
+        "pipelineMode": {
+            "enum": [
+                "Integrated",
+                "Classic"
+            ],
+            "description": "This property allows you to set the pipeline mode for the application pool."
         }
     },
     "type": "object",
@@ -39,6 +46,10 @@
             "$ref": "#/definitions/protocol",
             "title": "Protocol",
             "description": "This property is optional & allows you to set http or https"
+        },
+        "pipelineMode": {
+            "$ref": "#/definitions/pipelineMode",
+            "description": "This property allows you to set the pipeline mode for the application pool."
         }
     },
     "required": [

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -8,6 +8,7 @@ export interface Isettings {
     url?: string;
     clr: clrVersion;
     protocol: protocolType;
+    pipelineMode?: pipelineMode; // New property for pipeline mode
 }
 
 export enum clrVersion {
@@ -15,6 +16,10 @@ export enum clrVersion {
 	v20 = <any>"v2.0"
 }
 
+export enum pipelineMode {
+    Integrated = <any>"Integrated",
+    Classic = <any>"Classic" // New enum value for Classic pipeline mode
+}
 
 export enum protocolType {
     http = <any>"http",
@@ -45,7 +50,8 @@ export function getSettings(uri:vscode.Uri| undefined):Isettings{
         port : getRandomPort(),
         path: './',
         clr: clrVersion.v40,
-        protocol: protocolType.http
+        protocol: protocolType.http,
+        pipelineMode: pipelineMode.Integrated // Default to Integrated if not set
     };
 
     let settings:Isettings;


### PR DESCRIPTION
Related to #654

Adds support for Classic pipeline mode in IIS Express integration for VS Code, enhancing flexibility for project configurations.

- **Updates `IISExpress.ts`**:
  - Introduces a new optional property `pipelineMode` in the `IExpressArguments` interface to allow specifying the pipeline mode.
  - Modifies the application pool assignment logic to support both Integrated and Classic pipeline modes based on the CLR version and the newly introduced `pipelineMode` property.
- **Modifies `iisexpress-schema.json`**:
  - Extends the JSON schema with a new `pipelineMode` property, allowing users to specify their desired pipeline mode in the `iisexpress.json` configuration file.
- **Adjusts `settings.ts`**:
  - Adds handling for the `pipelineMode` property within the `getSettings` function, ensuring the new configuration option is properly processed and applied.

These changes address the need for Classic pipeline mode support, as requested in the issue, by providing the necessary options and logic to configure the pipeline mode for IIS Express directly from the VS Code extension settings.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/warrenbuckley/IIS-Express-Code/issues/654?shareId=87ed8223-fe98-47a1-8ae1-1f2cbbf22d7a).